### PR TITLE
[Proposed fix] Pass conn id from SQL operator to hook

### DIFF
--- a/kinetica_provider/operator/sql.py
+++ b/kinetica_provider/operator/sql.py
@@ -22,4 +22,4 @@ class KineticaSqlOperator(SQLExecuteQueryOperator):
         super().__init__(conn_id=kinetica_conn_id, **kwargs)
 
     def get_db_hook(self) -> KineticaSqlHook:
-        return KineticaSqlHook()
+        return KineticaSqlHook(kinetica_conn_id=self.conn_id)


### PR DESCRIPTION
Noticed that runs using this operator in our dev environment were failing because they were using the `kinetica_default` connection.

```
[2024-02-06, 21:14:19 UTC] {base.py:73} INFO - Using connection ID 'kinetica_default' for task execution.
```

Despite us passing a new conn_id to the SQL operator:

```
ensure_namespace_exists = KineticaSqlOperator(
    task_id="ensure_namespace_exists",
    kinetica_conn_id="kinetica_{{ params.dest_kinetica_cluster_value }}",
    doc_md="Ensure the namespace exists, if not create it.",
    sql=f"CREATE SCHEMA IF NOT EXISTS {prefixed_namespace}",
)
```